### PR TITLE
Use KDIR variable for kernel headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ pip3 install torch torchvision numpy pillow
 
 # Build the project
 make
+
+# If your kernel headers are in a non-standard location, override KDIR
+# which defaults to /lib/modules/$(uname -r)/build
+# make KDIR=/path/to/custom/headers
 ```
 
 ## Usage
@@ -123,7 +127,8 @@ The script will:
 
 - Fixed input size (28x28 grayscale images)
 - Simple architecture (single hidden layer)
-- May require kernel headers specific to your system (adjust paths in Makefile)
+- May require kernel headers specific to your system. Set the `KDIR` variable if
+  the headers are not in `/lib/modules/$(uname -r)/build`.
 
 ## License
 

--- a/makefile
+++ b/makefile
@@ -3,8 +3,11 @@ BPF_LLVM_STRIP ?= llvm-strip
 LDFLAGS = -lbpf
 CC ?= gcc
 CFLAGS ?= -O2 -g -Wall
-KERN_HEADERS = -I/usr/src/linux-headers-6.8.0-55-generic/arch/x86/include/generated/uapi \
-               -I/usr/src/linux-headers-6.8.0-55/arch/x86/include/uapi
+
+# Location of the kernel headers. Override if your headers live elsewhere.
+KDIR ?= /lib/modules/$(shell uname -r)/build
+KERN_HEADERS = -I$(KDIR)/arch/x86/include/generated/uapi \
+               -I$(KDIR)/arch/x86/include/uapi
 
 BPF_SRC = kerinferencel.bpf.c
 BPF_OBJ = kerinferencel.bpf.o


### PR DESCRIPTION
## Summary
- introduce `KDIR` variable in `makefile`
- use `$(KDIR)/arch/...` to locate kernel headers
- document `KDIR` in the README

## Testing
- `make clean && make > /tmp/make.log 2>&1 || true`
- `tail -n 20 /tmp/make.log`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_68409a9e3a2c8328a9d780c81855b3c8